### PR TITLE
Handle ISO-8859-1 files properly

### DIFF
--- a/lib/mof/scanner.rb
+++ b/lib/mof/scanner.rb
@@ -45,7 +45,7 @@ module Scanner
 #    $stderr.puts "fill_queue(#{@line.split('').inspect})"
     @line.chomp!  # remove $/
     if @iconv
-      if String.method_defined? encode
+      if String.method_defined? 'encode'
         @line = @line.encode( "ISO-8859-1", @iconv )
       else
         @line = Iconv.conv( "ISO-8859-1", @iconv, @line )


### PR DESCRIPTION
- When attempting to open files, UTF-8 is the default encoding
  used.  However, some of the DSC MOF files from
  https://github.com/PowerShell/DscResources are in fact
  ISO-8859-1, and contain bytes that are not valid UTF-8,
  such as \x91 and \x92 (smartquotes) and \xAE (copyright)
